### PR TITLE
Autlogger Tampering Atomics

### DIFF
--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -1151,3 +1151,49 @@ atomic_tests:
       Remove-Item -Path "HKCU:\Software\Microsoft\Windows Script\Settings" -Recurse -Force 2> $null
     name: powershell
     elevation_required: true
+- name: Disable EventLog-Application Auto Logger Session Via Registry - Cmd
+  description: This atomic simulates an activity where an attacker disables the EventLog-Application ETW Auto Logger session using the reg.exe utility to update the Windows registry value "Start". This would effectivly disable the Event log application channel. The changes would only take effect after a restart.
+  supported_platforms:
+  - windows
+  executor:
+    command: reg add "HKLM\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application" /v "Start" /t REG_DWORD /d "0" /f
+    cleanup_command: reg add "HKLM\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application" /v "Start" /t REG_DWORD /d "1" /f
+    name: command_prompt
+    elevation_required: true
+- name: Disable EventLog-Application Auto Logger Session Via Registry - PowerShell
+  description: This atomic simulates an activity where an attacker disables the EventLog-Application ETW Auto Logger session using the powershell.exe "New-ItemProperty" cmdlet to update the Windows registry value "Start". This would effectivly disable the Event log application channel. The changes would only take effect after a restart.
+  supported_platforms:
+  - windows
+  executor:
+    command: New-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application -Name Start -Value 0 -PropertyType "DWord" -Force
+    cleanup_command: New-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application -Name Start -Value 1 -PropertyType "DWord" -Force
+    name: powershell
+    elevation_required: true
+- name: Disable EventLog-Application ETW Provider Via Registry - Cmd
+  description: This atomic simulates an activity where an attacker disables a specific ETW provider from the EventLog-Application ETW Auto Logger session using the reg.exe utility to update the Windows registry value "Enabled". This would effectivly remove that provider from the session and cause to not emit any logs of that type. The changes would only take effect after a restart.
+  supported_platforms:
+  - windows
+  input_arguments:
+    ETWProviderGUID:
+      type: string
+      default: "{B6D775EF-1436-4FE6-BAD3-9E436319E218}"
+      description: Microsoft-Windows-SenseIR ETW Provider GUID
+  executor:
+    command: reg add "HKLM\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application\#{ETWProviderGUID}" /v "Enabled" /t REG_DWORD /d "0" /f
+    cleanup_command: reg add "HKLM\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application\#{ETWProviderGUID}" /v "Enabled" /t REG_DWORD /d "1" /f
+    name: command_prompt
+    elevation_required: true
+- name: Disable EventLog-Application ETW Provider Via Registry - PowerShell
+  description: This atomic simulates an activity where an attacker disables a specific ETW provider from the EventLog-Application ETW Auto Logger session using the powershell.exe "New-ItemProperty" cmdlet to update the Windows registry value "Enabled". This would effectivly remove that provider from the session and cause to not emit any logs of that type. The changes would only take effect after a restart.
+  supported_platforms:
+  - windows
+  input_arguments:
+    ETWProviderGUID:
+      type: string
+      default: "{B6D775EF-1436-4FE6-BAD3-9E436319E218}"
+      description: Microsoft-Windows-SenseIR ETW Provider GUID
+  executor:
+    command: New-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application\#{ETWProviderGUID}" -Name Enabled -Value 0 -PropertyType "DWord" -Force
+    cleanup_command: New-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\WMI\Autologger\EventLog-Application\#{ETWProviderGUID}" -Name Enabled -Value 1 -PropertyType "DWord" -Force
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
**Details:**

This PR adds new atomics that tamper with an Autologger session as well as one of its registered provider.

**Testing:**

The following screenshot showcase that the test are executing successfully.
 
![image](https://github.com/user-attachments/assets/2244570d-6f97-43ae-8089-10261062501f)

In order to see the results you would need to reboot the machine in the case of disabling the AutoLogger session.

As for disabling the provider, by default this atomic disables the SenseIR provider which is a bit hard to test but it once it is disabled, we will not receive new events from that provider for the EventLog application auto logger session. Feel free to use another provider that easily tested :)